### PR TITLE
rear cam filename fix

### DIFF
--- a/tesla_dashcam/tesla_dashcam.py
+++ b/tesla_dashcam/tesla_dashcam.py
@@ -1154,7 +1154,7 @@ def get_movie_files(source_folder, exclude_subdirs, video_settings):
             right_filename = str(filename_timestamp) + "-right_repeater.mp4"
             right_path = os.path.join(movie_folder, right_filename)
 
-            rear_filename = str(filename_timestamp) + "-rear_view.mp4"
+            rear_filename = str(filename_timestamp) + "-back.mp4"
             rear_path = os.path.join(movie_folder, rear_filename)
 
             # Get meta data for each video to determine creation time and duration.


### PR DESCRIPTION
The rear camera files generated for my M3 on 2019.32.10.1 end in `-back.mp4`