### PR TITLE
Fix missing fonts in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3
 
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y ffmpeg tzdata && apt-get autoremove && apt-get clean
+RUN apt-get update && apt-get install -y ffmpeg tzdata fonts-freefont-ttf && apt-get autoremove && apt-get clean
 
 
 WORKDIR /usr/src/app/tesla_dashcam

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3
 
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y ffmpeg && apt-get autoremove && apt-get clean
+RUN apt-get update && apt-get install -y ffmpeg tzdata && apt-get autoremove && apt-get clean
 
 
 WORKDIR /usr/src/app/tesla_dashcam


### PR DESCRIPTION
Addresses the missing font issue in the Docker version in #74.

I also added the `tzdata` package so you can specify the desired timezone for the timestamps. I can pull that out if needed.