### PR TITLE
Added x265 compatibility tag for QuickTime on macOS

### DIFF
--- a/tesla_dashcam/tesla_dashcam.py
+++ b/tesla_dashcam/tesla_dashcam.py
@@ -3007,6 +3007,10 @@ def main() -> None:
             if sys.platform == "darwin":
                 video_encoding = video_encoding + ["-allow_sw", "1"]
                 encoding = encoding + "_mac"
+
+                # x265 + Quicktime compatibilty for macOS
+                if encoding == "x265_mac":
+                  video_encoding = video_encoding + ["-vtag", "hvc1"]
             else:
                 if args.gpu_type is None:
                     print(


### PR DESCRIPTION
This change allows QuickTime on macOS to playback files encoded using x265. 