### PR TITLE
Add support for formatted text overlay

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,78 +109,56 @@ Usage
 
 .. code:: bash
 
-    usage: tesla_dashcam.py [-h] [--version]
-                            [--loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
-                            [--temp_dir TEMP_DIR] [--no-notification]
-                            [--skip_existing] [--delete_source]
-                            [--exclude_subdirs] [--monitor] [--monitor_once]
-                            [--monitor_trigger MONITOR_TRIGGER]
-                            [--layout {WIDESCREEN,FULLSCREEN,PERSPECTIVE,CROSS,DIAMOND}]
-                            [--perspective] [--scale CLIP_SCALE [CLIP_SCALE ...]]
-                            [--mirror] [--rear] [--swap] [--no-swap]
-                            [--swap_frontrear] [--background BACKGROUND]
-                            [--no-front] [--no-left] [--no-right] [--no-rear]
-                            [--no-timestamp] [--halign {LEFT,CENTER,RIGHT}]
-                            [--valign {TOP,MIDDLE,BOTTOM}] [--font FONT]
-                            [--fontsize FONTSIZE] [--fontcolor FONTCOLOR]
-                            [--start_timestamp START_TIMESTAMP]
-                            [--end_timestamp END_TIMESTAMP]
-                            [--start_offset START_OFFSET]
-                            [--end_offset END_OFFSET] [--output OUTPUT]
-                            [--motion_only] [--slowdown SLOW_DOWN]
-                            [--speedup SPEED_UP] [--chapter_offset CHAPTER_OFFSET]
-                            [--merge] [--keep-intermediate] [--no-gpu]
-                            [--no-faststart]
+    usage: tesla_dashcam.py [-h] [--version] [--loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [--temp_dir TEMP_DIR]
+                            [--no-notification] [--skip_existing] [--delete_source] [--exclude_subdirs] [--monitor]
+                            [--monitor_once] [--monitor_trigger MONITOR_TRIGGER]
+                            [--layout {WIDESCREEN,FULLSCREEN,PERSPECTIVE,CROSS,DIAMOND}] [--perspective]
+                            [--scale CLIP_SCALE [CLIP_SCALE ...]] [--mirror] [--rear] [--swap] [--no-swap] [--swap_frontrear]      
+                            [--background BACKGROUND] [--no-front] [--no-left] [--no-right] [--no-rear] [--no-timestamp]
+                            [--halign {LEFT,CENTER,RIGHT}] [--valign {TOP,MIDDLE,BOTTOM}] [--font FONT] [--fontsize FONTSIZE]      
+                            [--fontcolor FONTCOLOR] [--text_overlay_fmt TEXT_OVERLAY_FMT] [--start_timestamp START_TIMESTAMP]      
+                            [--end_timestamp END_TIMESTAMP] [--start_offset START_OFFSET] [--end_offset END_OFFSET]
+                            [--output OUTPUT] [--motion_only] [--slowdown SLOW_DOWN] [--speedup SPEED_UP]
+                            [--chapter_offset CHAPTER_OFFSET] [--merge] [--keep-intermediate]
+                            [--set_moviefile_timestamp {START,STOP}] [--gpu] [--gpu_type {nvidia,intel,RPi}] [--no-faststart]      
                             [--quality {LOWEST,LOWER,LOW,MEDIUM,HIGH}]
-                            [--compression {ultrafast,superfast,veryfast,faster,fast,medium,slow,slower,veryslow}]
-                            [--fps FPS] [--ffmpeg FFMPEG] [--encoding {x264,x265}]
-                            [--enc ENC] [--check_for_update]
-                            [--no-check_for_update] [--include_test]
+                            [--compression {ultrafast,superfast,veryfast,faster,fast,medium,slow,slower,veryslow}] [--fps FPS]     
+                            [--ffmpeg FFMPEG] [--encoding {x264,x265}] [--enc ENC] [--check_for_update] [--no-check_for_update]    
+                            [--include_test]
                             [source [source ...]]
 
     tesla_dashcam - Tesla DashCam & Sentry Video Creator
 
     positional arguments:
-      source                Folder(s) (events) containing the saved camera files.
-                            Filenames can be provided as well to manage individual
-                            clips. (default: None)
+      source                Folder(s) (events) containing the saved camera files. Filenames can be provided as well to manage      
+                            individual clips. (default: None)
 
     optional arguments:
       -h, --help            show this help message and exit
-      --version             show program''s version number and exit
+      --version             show program's version number and exit
       --loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                             Logging level. (default: INFO)
       --temp_dir TEMP_DIR   Path to store temporary files. (default: None)
-      --no-notification     Do not create a notification upon completion.
-                            (default: True)
+      --no-notification     Do not create a notification upon completion. (default: True)
 
     Video Input:
       Options related to what clips and events to process.
 
-      --skip_existing       Skip creating encoded video file if it already exist.
-                            Note that only existence is checked, not if layout
-                            etc. are the same. (default: False)
-      --delete_source       Delete the processed files upon completion. (default:
-                            False)
-      --exclude_subdirs     Do not search sub folders (events) for video files to
-                            process. (default: False)
+      --skip_existing       Skip creating encoded video file if it already exist. Note that only existence is checked, not if      
+                            layout etc. are the same. (default: False)
+      --delete_source       Delete the processed files upon completion. (default: False)
+      --exclude_subdirs     Do not search sub folders (events) for video files to process. (default: False)
 
     Trigger Monitor:
-      Parameters for monitoring of insertion of TeslaCam drive, folder, or file
-      existence.
+      Parameters for monitoring of insertion of TeslaCam drive, folder, or file existence.
 
-      --monitor             Enable monitoring for drive to be attached with
-                            TeslaCam folder. (default: False)
-      --monitor_once        Enable monitoring and exit once drive with TeslaCam
-                            folder has been attached and files processed.
+      --monitor             Enable monitoring for drive to be attached with TeslaCam folder. (default: False)
+      --monitor_once        Enable monitoring and exit once drive with TeslaCam folder has been attached and files processed.      
                             (default: False)
       --monitor_trigger MONITOR_TRIGGER
-                            Trigger file to look for instead of waiting for drive
-                            to be attached. Once file is discovered then
-                            processing will start, file will be deleted when
-                            processing has been completed. If source is not
-                            provided then folder where file is located will be
-                            used as source. (default: None)
+                            Trigger file to look for instead of waiting for drive to be attached. Once file is discovered then     
+                            processing will start, file will be deleted when processing has been completed. If source is not       
+                            provided then folder where file is located will be used as source. (default: None)
 
     Video Layout:
       Set what the layout of the resulting video should be
@@ -192,7 +170,7 @@ Usage
                                 PERSPECTIVE: Similar to FULLSCREEN but then with side cameras in perspective.
                                 CROSS: Front camera center top, side cameras underneath, and rear camera center bottom.
                                 DIAMOND: Front camera center top, side cameras below front camera left and right of front, and rear camera center bottom.
-                             (default: FULLSCREEN)
+                            (default: FULLSCREEN)
       --perspective         Show side cameras in perspective. (default: False)
       --scale CLIP_SCALE [CLIP_SCALE ...]
                             Set camera clip scale for all clips, scale of 1 is 1280x960 camera clip.
@@ -200,33 +178,26 @@ Usage
                             for example:
                               --scale 0.5                                             all are 640x480
                               --scale 640x480                                         all are 640x480
-                              --scale 0.5 --scale camera=front 1                      all are 640x480 except front at 1280x960
+                              --scale 0.5 --scale camera=front 1                      all are 640x480 except front at 1280x960     
                               --scale camera=left .25 --scale camera=right 320x240    left and right are set to 320x240
                             Defaults:
                                 WIDESCREEN: 1/2 (front 1280x960, others 640x480, video is 1920x1920)
                                 FULLSCREEN: 1/2 (640x480, video is 1920x960)
                                 CROSS: 1/2 (640x480, video is 1280x1440)
                                 DIAMOND: 1/2 (640x480, video is 1920x976)
-                             (default: None)
-      --mirror              Video from side and rear cameras as if being viewed
-                            through the mirror. Default when not providing
-                            parameter --no-front. Cannot be used in combination
-                            with --rear. (default: None)
-      --rear                Video from side and rear cameras as if looking
-                            backwards. Default when providing parameter --no-
-                            front. Cannot be used in combination with --mirror.
                             (default: None)
-      --swap                Swap left and right cameras in output, default when
-                            side and rear cameras are as if looking backwards. See
-                            --rear parameter. (default: None)
-      --no-swap             Do not swap left and right cameras, default when side
-                            and rear cameras are as if looking through a mirror.
-                            Also see --mirror parameter (default: None)
-      --swap_frontrear      Swap front and rear cameras in output. (default:
-                            False)
+      --mirror              Video from side and rear cameras as if being viewed through the mirror. Default when not providing     
+                            parameter --no-front. Cannot be used in combination with --rear. (default: None)
+      --rear                Video from side and rear cameras as if looking backwards. Default when providing parameter --no-       
+                            front. Cannot be used in combination with --mirror. (default: None)
+      --swap                Swap left and right cameras in output, default when side and rear cameras are as if looking
+                            backwards. See --rear parameter. (default: None)
+      --no-swap             Do not swap left and right cameras, default when side and rear cameras are as if looking through a     
+                            mirror. Also see --mirror parameter (default: None)
+      --swap_frontrear      Swap front and rear cameras in output. (default: False)
       --background BACKGROUND
-                            Background color for video. Can be a color string or
-                            RGB value. Also see --fontcolor. (default: black)
+                            Background color for video. Can be a color string or RGB value. Also see --fontcolor. (default:        
+                            black)
 
     Camera Exclusion:
       Exclude one or more cameras:
@@ -236,19 +207,17 @@ Usage
       --no-right            Exclude right camera from video. (default: False)
       --no-rear             Exclude rear camera from video. (default: False)
 
-    Timestamp:
-      Options on how to show date/time in resulting video:
+    Text Overlay:
+      Options on how to show text in resulting video:
 
       --no-timestamp        Do not show timestamp in video (default: False)
       --halign {LEFT,CENTER,RIGHT}
                             Horizontal alignment for timestamp (default: None)
       --valign {TOP,MIDDLE,BOTTOM}
                             Vertical Alignment for timestamp (default: None)
-      --font FONT           Fully qualified filename (.ttf) to the font to be
-                            chosen for timestamp. (default: /Library/Fonts/Arial
-                            Unicode.ttf)
-      --fontsize FONTSIZE   Font size for timestamp. Default is scaled based on
-                            resulting video size. (default: None)
+      --font FONT           Fully qualified filename (.ttf) to the font to be chosen for timestamp. (default:
+                            /Windows/Fonts/arial.ttf)
+      --fontsize FONTSIZE   Font size for timestamp. Default is scaled based on resulting video size. (default: None)
       --fontcolor FONTCOLOR
                             Font color for timestamp. Any color is accepted as a color string or RGB value.
                             Some potential values are:
@@ -258,11 +227,21 @@ Usage
                                 Red
                             :    0x2E8B57
                             For more information on this see ffmpeg documentation for color: https://ffmpeg.org/ffmpeg-utils.html#Color (default: white)
+      --text_overlay_fmt TEXT_OVERLAY_FMT
+                            Format string for text overlay.
+                            Valid format variables:
+                                local_timestamp_rolling - Local time which continuously updates
+                                local_timestamp - Local time that does not continuously update
+                                event_timestamp - Timestamp from events.json (if provided)
+                                event_city - City name from events.json (if provided)
+                                event_reason - Recording reason from events.json (if provided)
+                                event_latitude - Estimated latitude from events.json (if provided)
+                                event_longitude - Estimated longitude from events.json (if provided)
+                            (default: {local_timestamp_rolling})
 
     Timestamp Restriction:
-      Restrict video to be between start and/or end timestamps. Timestamp to be
-      provided in a ISO-8601 format (see https://fits.gsfc.nasa.gov/iso-
-      time.html for examples)
+      Restrict video to be between start and/or end timestamps. Timestamp to be provided in a ISO-8601 format (see
+      https://fits.gsfc.nasa.gov/iso-time.html for examples)
 
       --start_timestamp START_TIMESTAMP
                             Starting timestamp (default: None)
@@ -273,69 +252,53 @@ Usage
       Start and/or end offsets for events
 
       --start_offset START_OFFSET
-                            Skip x number of seconds from start of event for
-                            resulting video. (default: None)
+                            Skip x number of seconds from start of event for resulting video. (default: None)
       --end_offset END_OFFSET
-                            Ignore the last x seconds of the event for resulting
-                            video (default: None)
+                            Ignore the last x seconds of the event for resulting video (default: None)
 
     Video Output:
       Options related to resulting video creation.
 
       --output OUTPUT       Path/Filename for the new movie file. Event files will be stored in same folder.
-                             (default: /Users/ehendrix/Movies/Tesla_Dashcam/)
-      --motion_only         Fast-forward through video when there is no motion.
-                            (default: False)
-      --slowdown SLOW_DOWN  Slow down video output. Accepts a number that is then
-                            used as multiplier, providing 2 means half the speed.
-      --speedup SPEED_UP    Speed up the video. Accepts a number that is then used
-                            as a multiplier, providing 2 means twice the speed.
+                            (default: C:\Users\jashir\Videos\Tesla_Dashcam\)
+      --motion_only         Fast-forward through video when there is no motion. (default: False)
+      --slowdown SLOW_DOWN  Slow down video output. Accepts a number that is then used as multiplier, providing 2 means half the   
+                            speed.
+      --speedup SPEED_UP    Speed up the video. Accepts a number that is then used as a multiplier, providing 2 means twice the    
+                            speed.
       --chapter_offset CHAPTER_OFFSET
-                            Offset in seconds for chapters in merged video.
-                            Negative offset is # of seconds before the end of the
-                            subdir video, positive offset if # of seconds after
-                            the start of the subdir video. (default: 0)
-      --merge               Merge the video files from different folders (events)
-                            into 1 big video file. (default: False)
-      --keep-intermediate   Do not remove the clip video files that are created
-                            (default: False)
+                            Offset in seconds for chapters in merged video. Negative offset is # of seconds before the end of the  
+                            subdir video, positive offset if # of seconds after the start of the subdir video. (default: 0)        
+      --merge               Merge the video files from different folders (events) into 1 big video file. (default: False)
+      --keep-intermediate   Do not remove the clip video files that are created (default: False)
+      --set_moviefile_timestamp {START,STOP}
+                            Match modification timestamp of resulting video files to event timestamp. Use START to match with      
+                            when the event started, STOP for end time of the event. (default: START)
 
     Advanced encoding settings:
       Advanced options for encoding
 
-      --no-gpu (Mac)|--gpu (Non-Mac Only)
-                            Use GPU acceleration, only enable if supported by hardware.
-                             MAC: All MACs with Haswell CPU or later support this (Macs after 2013).
+      --gpu                 Use GPU acceleration, only enable if supported by hardware.
+                            MAC: All MACs with Haswell CPU or later support this (Macs after 2013).
                                   See following link as well:
-                                     https://en.wikipedia.org/wiki/List_of_Macintosh_models_grouped_by_CPU_type#Haswell
-                             (default: False)
-
-      --gpu_type {nvidia,intel,RPi} (Non-Mac only)
-                            Type of graphics card (GPU) in the system. This
-                            determines the encoder that will be used.This
-                            parameter is mandatory if --gpu is provided. (default:
-                            None)
-
-      --no-faststart        Do not enable flag faststart on the resulting video
-                            files. Use this when using a network share and errors
-                            occur during encoding. (default: False)
+                                    https://en.wikipedia.org/wiki/List_of_Macintosh_models_grouped_by_CPU_type#Haswell
+                            (default: False)
+      --gpu_type {nvidia,intel,RPi}
+                            Type of graphics card (GPU) in the system. This determines the encoder that will be used.This
+                            parameter is mandatory if --gpu is provided. (default: None)
+      --no-faststart        Do not enable flag faststart on the resulting video files. Use this when using a network share and     
+                            errors occur during encoding. (default: False)
       --quality {LOWEST,LOWER,LOW,MEDIUM,HIGH}
-                            Define the quality setting for the video, higher
-                            quality means bigger file size but might not be
+                            Define the quality setting for the video, higher quality means bigger file size but might not be       
                             noticeable. (default: LOWER)
       --compression {ultrafast,superfast,veryfast,faster,fast,medium,slow,slower,veryslow}
-                            Speed to optimize video. Faster speed results in a
-                            bigger file. This does not impact the quality of the
-                            video, just how much time is used to compress it.
-                            (default: medium)
-      --fps FPS             Frames per second for resulting video. Tesla records
-                            at about 33fps hence going higher wouldn't do much as
-                            frames would just be duplicated. Default is 24fps
-                            which is the standard for movies and TV shows
-                            (default: 24)
-      --ffmpeg FFMPEG       Path and filename for ffmpeg. Specify if ffmpeg is not
-                            within path. (default: /Users/ehendrix/Documents_local
-                            /GitHub/tesla_dashcam/tesla_dashcam/ffmpeg)
+                            Speed to optimize video. Faster speed results in a bigger file. This does not impact the quality of    
+                            the video, just how much time is used to compress it. (default: medium)
+      --fps FPS             Frames per second for resulting video. Tesla records at about 33fps hence going higher wouldn't do     
+                            much as frames would just be duplicated. Default is 24fps which is the standard for movies and TV      
+                            shows (default: 24)
+      --ffmpeg FFMPEG       Path and filename for ffmpeg. Specify if ffmpeg is not within path. (default:
+                            d:\src\tesla_dashcam\tesla_dashcam\ffmpeg.exe)
       --encoding {x264,x265}
                             Encoding to use for video creation.
                                 x264: standard encoding, can be viewed on most devices but results in bigger file.
@@ -348,11 +311,9 @@ Usage
 
       --check_for_update    Check for update and exit. (default: False)
       --no-check_for_update
-                            A check for new updates is performed every time. With
-                            this parameter that can be disabled (default: False)
-      --include_test        Include test (beta) releases when checking for
-                            updates. (default: False)
-
+                            A check for new updates is performed every time. With this parameter that can be disabled (default:    
+                            False)
+      --include_test        Include test (beta) releases when checking for updates. (default: False)
 
 Positional Argument
 -------------------
@@ -611,10 +572,32 @@ exclude one or more cameras from the resulting video.
 
   Exclude the rear camera from the resulting video.
 
-Timestamp
+Text Overlay
 ---------
 
-Following parameters are to change settings for the timestamp that is being added to the resulting video.
+Following parameters are to change settings for the text that is being added to the resulting video.
+
+*--text-overlay-fmt*
+
+  Default: {local_timestamp_rolling}
+
+  Sets the format string for the text overlayed in the video.
+  Valid format specifiers:
+  
+  `local_timestamp_rolling`: Local time which continuously updates, string
+
+  `local_timestamp`: Local time that does not continuously update, string
+
+  `event_timestamp`: Timestamp from events.json (if provided), string
+
+  `event_city`: City name from events.json (if provided), string
+
+  `event_reason`: Recording reason from events.json (if provided), string
+
+  `event_latitude`: Estimated latitude from events.json (if provided), float
+
+  `event_longitude`: Estimated longitude from events.json (if provided), float
+
 
 *--no-timestamp*
 

--- a/tesla_dashcam/tesla_dashcam.py
+++ b/tesla_dashcam/tesla_dashcam.py
@@ -2559,8 +2559,7 @@ def main() -> None:
         "For more information on this see ffmpeg documentation for color: https://ffmpeg.org/ffmpeg-utils.html#Color",
     )
     text_overlay_group.add_argument(
-        "--text-overlay-fmt",
-        dest="text_overlay_fmt",
+        "--text_overlay_fmt",
         required=False,
         type=str,
         default="{local_timestamp_rolling}",

--- a/tesla_dashcam/tesla_dashcam.py
+++ b/tesla_dashcam/tesla_dashcam.py
@@ -1525,9 +1525,12 @@ def create_movie(
                 continue
 
             # Add this file in our join list.
+            # NOTE: Recent ffmpeg changes requires Windows paths in this file to look like
+            # file 'file:<actual path>'
+            # https://trac.ffmpeg.org/ticket/2702
             fp.write(
-                "file '"
-                + video_clip["video_filename"]
+                "file 'file:"
+                + video_clip["video_filename"].replace(os.sep, '/')
                 + "'{linesep}".format(linesep=os.linesep)
             )
             total_clips = total_clips + 1

--- a/tesla_dashcam/tesla_dashcam.py
+++ b/tesla_dashcam/tesla_dashcam.py
@@ -2559,19 +2559,20 @@ def main() -> None:
         "For more information on this see ffmpeg documentation for color: https://ffmpeg.org/ffmpeg-utils.html#Color",
     )
     text_overlay_group.add_argument(
-        "--text_overlay_fmt",
+        "--text-overlay-fmt",
+        dest="text_overlay_fmt",
         required=False,
         type=str,
         default="{local_timestamp_rolling}",
         help="R|Format string for text overlay.\n"
         "Valid format variables:\n"
-        "    local_timestamp_rolling - Local time which continuously updates\n"
-        "    local_timestamp - Local time that does not continuously update\n"
-        "    event_timestamp - Timestamp from events.json (if provided)\n"
-        "    event_city - City name from events.json (if provided)\n"
-        "    event_reason - Recording reason from events.json (if provided)\n"
-        "    event_latitude - Estimated latitude from events.json (if provided)\n"
-        "    event_longitude - Estimated longitude from events.json (if provided)\n"
+        "    local_timestamp_rolling - Local time which continuously updates, string\n"
+        "    local_timestamp - Local time that does not continuously update, string\n"
+        "    event_timestamp - Timestamp from events.json (if provided), string\n"
+        "    event_city - City name from events.json (if provided), string\n"
+        "    event_reason - Recording reason from events.json (if provided), string\n"
+        "    event_latitude - Estimated latitude from events.json (if provided), float\n"
+        "    event_longitude - Estimated longitude from events.json (if provided), float\n"
     )
 
     filter_group = parser.add_argument_group(


### PR DESCRIPTION
NOTE: I am a C++ dev. with _very_ minor Python experience, so if my script kiddie-ness shows let me know and I can fix it! 

I tried to follow the general naming convention and what not.

This PR brings in two changes:
- Support to parse newer dashcam footage `event.json` files + the ability to create your own format for the text over (previously it was just a timestamp).  This also exposes the text values for users to make custom ffmpeg expressions.
- A small fix for ffmpeg file access when combining video files on Windows.

## Examples

### Command
```
tesla_dashcam.py --halign LEFT --valign TOP --text_overlay_fmt "{event_city} ({event_latitude:.5f}, {event_longitude:.5f})\n{local_timestamp_rolling}\nRecording Reason: {event_reason}" "C:/Users/jake/Desktop/2020-05-16_13-11-53"
```
### Screen shots
With `event.json` present:
![vlcsnap-2020-05-20-08h53m02s717](https://user-images.githubusercontent.com/1000311/82468255-700e6a00-9a77-11ea-8ada-e584e4f51983.png)

Without `event.json` present:
![vlcsnap-2020-05-20-08h53m08s003](https://user-images.githubusercontent.com/1000311/82468266-76044b00-9a77-11ea-90d6-1e4f7008f7e6.png)

With bad/invalid format specifier:
![vlcsnap-2020-05-20-08h55m33s192](https://user-images.githubusercontent.com/1000311/82468527-be236d80-9a77-11ea-9571-b6e574fea61e.png)

Example with most of the variables available:
### Command
```
--halign LEFT --valign TOP --text_overlay_fmt "Default variables:\nlocal_timestamp: {local_timestamp}\nlocal_timestamp_rolling: {local_timestamp_rolling}\nevent_city: {event_city}\nevent_latitude: {event_latitude:.5f}\nevent_longitude: {event_longitude:.5f}\nevent_reason: {event_reason}\nevent_timestamp: {event_timestamp}\nevent_timestamp_countdown: {event_timestamp_countdown}\nevent_timestamp_countdown_rolling: {event_timestamp_countdown_rolling}\n\nffmpeg expression examples:\nframe_num: %{{frame_num}}\ntime code expression: %{{expr_int_format: floor((n/30)/60) : d : 2}}:%{{eif: mod(floor(n/30), 60) :d:2}}.%{{eif: mod(n, 30)+1 :d:2}}\npict_type: %{{pict_type}}" "C:/Users/jake/Desktop/2020-05-16_13-11-53"
```
### Screen shots
![vlcsnap-2020-05-21-14h59m31s806](https://user-images.githubusercontent.com/1000311/82610813-f4461780-9b73-11ea-9c88-4667f567ab14.png)
