### PR TITLE
Adding Intel vaapi Hardware Accelerated encoding parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ehendrix23/ffmpeg-alpine:4.0-buildstage as build-stage
+FROM timrettop/ffmpeg-alpine:4.0-buildstage as build-stage
 FROM python:3-alpine
 
 COPY --from=build-stage /tmp/fakeroot/bin /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM timrettop/ffmpeg-alpine:4.0-buildstage as build-stage
+FROM timrettop/ffmpeg-alpine12:4.0-buildstage as build-stage
 FROM python:3-alpine
 
 COPY --from=build-stage /tmp/fakeroot/bin /usr/local/bin
 COPY --from=build-stage /tmp/fakeroot/share /usr/local/share
 COPY --from=build-stage /tmp/fakeroot/include /usr/local/include
 COPY --from=build-stage /tmp/fakeroot/lib /usr/local/lib
+COPY --from=build-stage /tmp/fakeroot/opt /opt
 
 WORKDIR /usr/src/app/tesla_dashcam
 
@@ -20,5 +21,7 @@ RUN pip install -r requirements.txt
 ENV PYTHONUNBUFFERED=true 
 # Provide a default timezone
 ENV TZ=America/New_York
+# Add intel drivers
+ENV LD_LIBRARY_PATH=/opt/intel/mediasdk/lib64:/lib
 
 ENTRYPOINT [ "python3", "tesla_dashcam/tesla_dashcam.py" ]

--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ Usage
                             [--end_timestamp END_TIMESTAMP] [--start_offset START_OFFSET] [--end_offset END_OFFSET]
                             [--output OUTPUT] [--motion_only] [--slowdown SLOW_DOWN] [--speedup SPEED_UP]
                             [--chapter_offset CHAPTER_OFFSET] [--merge] [--keep-intermediate]
-                            [--set_moviefile_timestamp {START,STOP}] [--gpu] [--gpu_type {nvidia,intel,RPi}] [--no-faststart]      
+                            [--set_moviefile_timestamp {START,STOP}] [--gpu] [--gpu_type {nvidia,intel-qsv,intel-vaapi,RPi}] [--no-faststart]      
                             [--quality {LOWEST,LOWER,LOW,MEDIUM,HIGH}]
                             [--compression {ultrafast,superfast,veryfast,faster,fast,medium,slow,slower,veryslow}] [--fps FPS]     
                             [--ffmpeg FFMPEG] [--encoding {x264,x265}] [--enc ENC] [--check_for_update] [--no-check_for_update]    
@@ -317,7 +317,7 @@ Usage
                                   See following link as well:
                                     https://en.wikipedia.org/wiki/List_of_Macintosh_models_grouped_by_CPU_type#Haswell
                             (default: False)
-      --gpu_type {nvidia,intel,RPi}
+      --gpu_type {nvidia,intel-qsv,intel-vaapi,RPi}
                             Type of graphics card (GPU) in the system. This determines the encoder that will be used.This
                             parameter is mandatory if --gpu is provided. (default: None)
       --no-faststart        Do not enable flag faststart on the resulting video files. Use this when using a network share and     
@@ -858,7 +858,9 @@ The following parameters are more advanced settings to determine how ffmpeg shou
 
   All platforms except Macs. Provide the GPU type installed in the system.
 
-    intel: if INTEL GPU is installed
+    intel-qsv: if INTEL GPU is installed and ffmpeg binary has intel-qsv support. 
+
+    intel-vaapi: if newer INTEL GPU is installed and ffmpeg binary has intel-vaapi support. 
 
     nvidia: if NVIDIA GPU is installed
 
@@ -1167,7 +1169,7 @@ Layout so front is shown top middle with side cameras below it and font size of 
 
     python3 tesla_dashcam.py --layout FULLSCREEN --fontsize 24 /home/me/Tesla/2019-02-27_14-02-03
 
-Specify location of ffmpeg binay (in case ffmpeg is not in path):
+Specify location of ffmpeg binary (in case ffmpeg is not in path):
 
 * Windows:
 

--- a/tesla_dashcam/tesla_dashcam.py
+++ b/tesla_dashcam/tesla_dashcam.py
@@ -1915,8 +1915,8 @@ def create_intermediate_movie(
     ffmpeg_command = (
             [video_settings["ffmpeg_exec"]]
             + ["-loglevel", "error"]
-            + [video_settings["ffmpeg_hwdev"]]
-            + [video_settings["ffmpeg_hwout"]]
+            + video_settings["ffmpeg_hwdev"]
+            + video_settings["ffmpeg_hwout"]
             + ffmpeg_left_command
             + ffmpeg_front_command
             + ffmpeg_right_command
@@ -2100,8 +2100,8 @@ def create_movie(
     ffmpeg_command = (
             [video_settings["ffmpeg_exec"]]
             + ["-loglevel", "error"]
-            + [video_settings["ffmpeg_hwdev"]]
-            + [video_settings["ffmpeg_hwout"]]
+            + video_settings["ffmpeg_hwdev"]
+            + video_settings["ffmpeg_hwout"]
             + ffmpeg_params
             + ffmpeg_metadata
             + ["-y", movie_filename]
@@ -3633,8 +3633,8 @@ def main() -> int:
             video_encoding = video_encoding + ["-vtag", "hvc1"]
 
         # GPU acceleration enabled
-        ffmpeg_hwdev=[]
-        ffmpeg_hwout=[]
+        ffmpeg_hwdev = []
+        ffmpeg_hwout = []
         if use_gpu:
             print(f"{get_current_timestamp()}GPU acceleration is enabled")
             if sys.platform == "darwin":
@@ -3649,8 +3649,8 @@ def main() -> int:
                     return 0
                 if args.gpu_type == "intel-vaapi":
                     if sys.platform == "linux":
-                        ffmpeg_hwdev = ["-vaapi_device", "/dev/dri/renderD128"] 
-                        ffmpeg_hwout = ["-hwaccel_output_format", "vaapi"]
+                        ffmpeg_hwdev = ffmpeg_hwdev + ["-vaapi_device", "/dev/dri/renderD128"] 
+                        ffmpeg_hwout = ffmpeg_hwout + ["-hwaccel_output_format", "vaapi"]
 
                     else:
                         print(f"{get_current_timestamp()}Support to be added for vaapi on Windows.")

--- a/tesla_dashcam/tesla_dashcam.py
+++ b/tesla_dashcam/tesla_dashcam.py
@@ -3652,6 +3652,11 @@ def main() -> int:
                         ffmpeg_hwdev = ffmpeg_hwdev + ["-vaapi_device", "/dev/dri/renderD128"] 
                         ffmpeg_hwout = ffmpeg_hwout + ["-hwaccel_output_format", "vaapi"]
 
+                if args.gpu_type == "intel-qsv":
+                    if sys.platform == "linux":
+                        ffmpeg_hwdev = ffmpeg_hwdev + ["-qsv_device", "/dev/dri/renderD128"] 
+                        ffmpeg_hwout = ffmpeg_hwout + ["-hwaccel", "qsv"]
+
                     else:
                         print(f"{get_current_timestamp()}Support to be added for vaapi on Windows.")
                         return 0


### PR DESCRIPTION
This should help with #136 
A new --gpu_type called intel-vaapi will adjust the ffmpeg command construction to leverage hardware accelerated encoding in the intermediate and final movies. --gpu_type intel that used to call the QSV encoder still exists with the value intel-qsv.  

I wonder if an alias of intel to intel-qsv should be added to allow for backward compatibility to peoples existing scripts? 