### PR TITLE
Escape % characters in help strings to correct --help

### DIFF
--- a/tesla_dashcam/tesla_dashcam.py
+++ b/tesla_dashcam/tesla_dashcam.py
@@ -2974,7 +2974,7 @@ def main() -> int:
         default="%x %X",
         help="R|Format for timestamps.\n "
              "Determines how timestamps should be represented. Any valid value from strftime is accepted."
-             "Default is set '%x %X' which is locale's appropriate date and time representation"
+             "Default is set '%%x %%X' which is locale's appropriate date and time representation"
              "More info: https://strftime.org"
 
     )
@@ -3081,7 +3081,7 @@ def main() -> int:
         default="%Y-%m-%d_%H_%M",
         help="R|Format for timestamps in merge_template.\n "
              "Determines how timestamps should be represented within merge_template. Any valid value from strftime is accepted."
-             "Default is set '%Y-%m-%d_%H_%M'"
+             "Default is set '%%Y-%%m-%%d_%%H_%%M'"
              "More info: https://strftime.org"
 
     )


### PR DESCRIPTION
Avoids errors such as

Traceback (most recent call last):
  File "/Users/ska/projects/others/tesla_dashcam/tesla_dashcam/tesla_dashcam.py", line 3949, in <module>
    sys.exit(main())
  File "/Users/ska/projects/others/tesla_dashcam/tesla_dashcam/tesla_dashcam.py", line 3247, in main
    args = parser.parse_args()
  File "/usr/local/Cellar/python@3.9/3.9.1_4/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 1818, in parse_args
    args, argv = self.parse_known_args(args, namespace)
[...]
  File "/usr/local/Cellar/python@3.9/3.9.1_4/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 530, in _format_action
    help_text = self._expand_help(action)
  File "/usr/local/Cellar/python@3.9/3.9.1_4/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 626, in _expand_help
    return self._get_help_string(action) % params
TypeError: %x format: an integer is required, not dict

when running with --help.


edit: Rebased onto the dev branch