### PR TITLE
Fix typo in qsv arg check

### DIFF
--- a/tesla_dashcam/tesla_dashcam.py
+++ b/tesla_dashcam/tesla_dashcam.py
@@ -4215,7 +4215,7 @@ def main() -> int:
                                 "-hwaccel_output_format",
                                 "vaapi",
                             ]
-                    elif args.gpu_type == "qvc":
+                    elif args.gpu_type == "qsv":
                         if PLATFORM == "linux":
                             ffmpeg_hwdev = ffmpeg_hwdev + [
                                 "-qsv_device",


### PR DESCRIPTION
Fixes the typo when checking for the `qsv` `gpu_type` during argument building for ffmpeg