### PR TITLE
Trivial fix to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -372,7 +372,7 @@ or so.
   Upon completion a notification is provided on the screen that processing is completed. Use this parameter to
   disable this notification.
 
-  *--display_ts*
+*--display_ts*
 
   Add timestamp to the text output procuded.
 


### PR DESCRIPTION
The --display_ts option was incorrectly indented